### PR TITLE
fix: type errors on ipfs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+First, install dependencies:
+```bash
+npm install
+```
+
+Next, run the development server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
This PR fixes #6.

From what I could tell, incoming metadataURI values were invariably starting with `ipfs://`, so when i tried to filter them out, i just got a loading screen.

I noticed there was already a URL replacement function, so I reworked that one a little.   I also needed to import Head from next once I got past the fetch TypeError stuff.